### PR TITLE
fix values of log.debug messages

### DIFF
--- a/src/main/java/io/harness/cf/client/api/Evaluator.java
+++ b/src/main/java/io/harness/cf/client/api/Evaluator.java
@@ -155,16 +155,16 @@ public class Evaluator implements Evaluation {
         // Should Target be excluded - if in excluded list we return false
         if (isTargetInList(target, segment.getExcluded()) == true) {
           log.debug(
-              "Target %s excluded from segment %s via exclude list\n",
-              target.getName(), segment.getName());
+              format("Target %s excluded from segment %s via exclude list",
+              target.getName(), segment.getName()));
           return false;
         }
 
         // Should Target be included - if in included list we return true
         if (isTargetInList(target, segment.getIncluded()) == true) {
           log.debug(
-              "Target %s included in segment %s via include list\n",
-              target.getName(), segment.getName());
+              format("Target %s included in segment %s via include list",
+              target.getName(), segment.getName()));
           return true;
         }
 
@@ -173,8 +173,8 @@ public class Evaluator implements Evaluation {
           for (Clause rule : segment.getRules()) {
             if (compare(rule.getValues(), target, rule) == true) {
               log.debug(
-                  "Target %s included in segment %s via rules\n",
-                  target.getName(), segment.getName());
+                  format("Target %s included in segment %s via rules",
+                  target.getName(), segment.getName()));
               return true;
             }
           }


### PR DESCRIPTION
Debug messages were displaying %s instead of the values, 
fixed to use `String.format()` like other instances found in the repository, and removed redundant "\n" - logger adds new lines for each message.
other option is to use {} to get the logger auto replacement, it is more recommended IMO, but prefered to go with repo standard.